### PR TITLE
Fix syntax with logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/NKI-CCB/TRANSACT",
     packages=setuptools.find_packages(),
-    install_requires=['numpy', 'scipy', 'pandas', 'matplotlib', 'scikit-learn', 'logging'],
+    install_requires=['numpy', 'scipy', 'pandas', 'matplotlib', 'scikit-learn'],
     python_requires='>=3.6',
     classifiers=(
         "Programming Language :: Python :: 3",

--- a/transact/TRANSACT.py
+++ b/transact/TRANSACT.py
@@ -222,7 +222,7 @@ class TRANSACT:
         self.left_center = left_center
 
         # Compute kernel values
-        logging.info.('START COMPUTATION OF KERNEL MATRICES')
+        logging.info('START COMPUTATION OF KERNEL MATRICES')
         self.kernel_values_.fit(source_data, target_data, center=False)
 
         # Compute principal vectors
@@ -237,11 +237,11 @@ class TRANSACT:
 
         # Stop here if interpolation should not be computed.
         if not with_interpolation:
-            logging.info.('FINISHED TRANSACT ALIGNMENT WITHOUT INTERPOLATION')
+            logging.info('FINISHED TRANSACT ALIGNMENT WITHOUT INTERPOLATION')
             return self
 
         # Set up interpolation scheme
-        logging.info.('START INTERPOLATION')
+        logging.info('START INTERPOLATION')
         self.interpolation_ = Interpolation(self.kernel, self.kernel_params_, self.n_jobs)
         self.interpolation_.fit(self.principal_vectors_, self.kernel_values_)
 
@@ -250,7 +250,7 @@ class TRANSACT:
 
         self.is_fitted = True
 
-        logging.info.('FINISHED TRANSACT ALIGNMENT WITH INTERPOLATION')
+        logging.info('FINISHED TRANSACT ALIGNMENT WITH INTERPOLATION')
         return self
 
 


### PR DESCRIPTION
Some invocations of logging used the format:
logging.info.()
which includes and extra "." after info.
The correct logging line is:
logging.info()

Also remove logging from install_requires list. logging is part of the python standard library in python 3. An error is thrown when trying to install TRANSACT when logging is in the install_requires list.